### PR TITLE
Minor changes

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -62,10 +62,8 @@ class Gateway extends AbstractGateway
      */
     public function setTestMode($testMode)
     {
-        //TODO
-        //temp set http for test env!
         $this->setEndPoint(
-            $testMode ? 'http://3dsec.sberbank.ru/payment/rest/' : 'https://securepayments.sberbank.ru/payment/rest/'
+            $testMode ? 'https://3dsec.sberbank.ru/payment/rest/' : 'https://securepayments.sberbank.ru/payment/rest/'
         );
 
         return $this->setParameter('testMode', $testMode);


### PR DESCRIPTION
Здравствуйте, перестало работать тестовое апи оплаты. 

Если использовать адрес http://3dsec.sberbank.ru/payment/rest/register.do для тестовой оплаты с протоколом http, то будет такая ошибка
cURL error 7: Failed to connect to 3dsec.sberbank.ru port 80 after 25730 ms.  Ранее ее не было.


Если использовать https, то будет другая ошибка.

cURL error 60: SSL certificate problem: self-signed certificate in certificate chain (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://3dsec.sberbank.ru/payment/rest/register.do



Решение - вернуть https и установить сертификат минцифры.
Можете принять pr плз.